### PR TITLE
Fixed colorbar positioning with tight layout

### DIFF
--- a/calplot/calplot.py
+++ b/calplot/calplot.py
@@ -345,6 +345,8 @@ def calplot(data, how='sum',
             fig.subplots_adjust(right=0.8)
             cax = fig.add_axes([0.85, 0.025, 0.02, 0.95])
             fig.colorbar(axes[0].get_children()[1], cax=cax, orientation='vertical')
+            if tight_layout:
+                plt.tight_layout(rect=[0, 0, 0.8, 1])
 
     stitle_kws.update(suptitle_kws)
     plt.suptitle(suptitle, **stitle_kws)


### PR DESCRIPTION
This should fix https://github.com/tomkwok/calplot/issues/4.
The issue seems to be that plt.tight_layout() and fig.subplots_adjust() do not work well with each other. 

I have to admit it's not the most beautiful code, but it seems to work fine.

Resulting in:
![image](https://user-images.githubusercontent.com/28652053/111230386-d86e9f00-85e7-11eb-8185-7f6f7766127f.png)
Instead of: 
![image](https://user-images.githubusercontent.com/28652053/111230604-2edbdd80-85e8-11eb-857e-c3af7fea9831.png)