### PR TITLE
yearplot no longer ignores dropzero kw

### DIFF
--- a/calplot/calplot.py
+++ b/calplot/calplot.py
@@ -98,7 +98,7 @@ def yearplot(data, year=None, how='sum',
         by_day = data.resample('D').agg(how)
 
     # Default to dropping zero values for a series with over 50% of rows being zero.
-    if by_day[by_day == 0].count() > 0.5 * by_day.count():
+    if not (dropzero is False) and (by_day[by_day == 0].count() > 0.5 * by_day.count()):
         dropzero = True
 
     if dropzero:


### PR DESCRIPTION
Yearplot is currently ignoring the `dropzero` keyword, which leads to undesired behaviour:

When running `calplot `with a series with an empty year,  the code `by_day = by_day.replace({0: np.nan}).dropna()` is ran regardless of the passed `dropzero `keyword, when the condition `by_day[by_day == 0].count() > 0.5 * by_day.count()` on line 101 is met.

This leads to a keyerror on line 128 when trying to filter the by_day object by a year that was dropped.
