### PR TITLE
Feature: Added on_click and on_format_coord options that use the date and value from the plot

### DIFF
--- a/calplot/calplot.py
+++ b/calplot/calplot.py
@@ -172,15 +172,20 @@ def yearplot(data, year=None, how='sum',
     def get_position_data(x, y) -> tuple[datetime.date, Any]:
         x0, x1 = ax.get_xlim()
         y0, y1 = ax.get_ylim()
-        col = int(np.floor((x - x0) / float(x1 - x0) * plot_data.shape[1]))
-        row = int(np.floor((y - y0) / float(y1 - y0) * plot_data.shape[0]))
-        pos_date = by_day.index[(col * 7) + (6 - row) - by_day.index[0].dayofweek].date()
+        col = int(np.floor((x - x0) / float(x1 - x0) * fill_data.shape[1]))
+        row = int(np.floor((y - y0) / float(y1 - y0) * fill_data.shape[0]))
+        date_index = (col * 7) + (6 - row) - by_day.index[0].dayofweek
+        if date_index < 0 or date_index >= len(by_day.index):
+            return (None, None)
+        pos_date = by_day.index[date_index].date()
         pos_val = plot_data[row, col]
         return (pos_date, pos_val)
 
     if on_format_coord:
         def wrapped_on_format_coord(x, y) -> str:
             (hover_date, hover_val) = get_position_data(x, y)
+            if not hover_date and not hover_val:
+                return ""
             return on_format_coord(hover_date, hover_val)
 
         ax.format_coord = wrapped_on_format_coord

--- a/calplot/calplot.py
+++ b/calplot/calplot.py
@@ -6,15 +6,15 @@ Plot Pandas time series data sampled by day in a heatmap per calendar year.
 
 import calendar
 import datetime
-from dateutil.relativedelta import relativedelta
+from typing import Any, Optional
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-
+from dateutil.relativedelta import relativedelta
 from matplotlib.colors import ColorConverter, ListedColormap
 from matplotlib.patches import Polygon
-import matplotlib.pyplot as plt
-from typing import Any, Optional
+
 
 def yearplot(data, year=None, how='sum',
              vmin=None, vmax=None,
@@ -168,6 +168,7 @@ def yearplot(data, year=None, how='sum',
     kwargs['edgecolors'] = linecolor
     ax.pcolormesh(plot_data, vmin=vmin, vmax=vmax, cmap=cmap, **kwargs)
 
+    # Helper function for mapping x/y coordinates on the colormesh back to dates and values.
     def get_position_data(x, y) -> tuple[datetime.date, Any]:
         x0, x1 = ax.get_xlim()
         y0, y1 = ax.get_ylim()

--- a/calplot/calplot.py
+++ b/calplot/calplot.py
@@ -6,7 +6,7 @@ Plot Pandas time series data sampled by day in a heatmap per calendar year.
 
 import calendar
 import datetime
-from typing import Any, Optional
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/calplot/calplot.py
+++ b/calplot/calplot.py
@@ -195,6 +195,8 @@ def yearplot(data, year=None, how='sum',
     if on_click:
         def wrapped_on_click(event) -> None:
             # Check if clicked ax is associated with this handler.
+            if not event.inaxes:
+                return
             if ax_row != event.inaxes.get_subplotspec().num1 or ax_col != event.inaxes.get_subplotspec().num2:
                 return
             if not event.xdata or not event.ydata:

--- a/calplot/calplot.py
+++ b/calplot/calplot.py
@@ -190,8 +190,13 @@ def yearplot(data, year=None, how='sum',
 
         ax.format_coord = wrapped_on_format_coord
 
+    ax_row = ax.get_subplotspec().num1
+    ax_col = ax.get_subplotspec().num2
     if on_click:
         def wrapped_on_click(event) -> None:
+            # Check if clicked ax is associated with this handler.
+            if ax_row != event.inaxes.get_subplotspec().num1 or ax_col != event.inaxes.get_subplotspec().num2:
+                return
             if not event.xdata or not event.ydata:
                 return
             (click_date, click_val) = get_position_data(event.xdata, event.ydata)


### PR DESCRIPTION
With this PR users will be able to attach a special on_click handler that gives access to the dates and values of their dataset when clicking a cell, as well as viewing the data on hover.

### Example code:
```python
from tkinter import messagebox

import calplot
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd

if __name__ == "__main__":
    all_days = pd.date_range("1/1/2019", periods=360, freq="D")
    days = np.random.choice(all_days, 500)
    events = pd.Series(np.random.randint(0, 10, len(days)), index=days)

    # New stuff starts here:
    def format(date, val):
        return f"{date}, {val}"

    def click(date, val):
        messagebox.showinfo(
            title="Clicked!", message=f"You clicked on date: {date}, value: {val}"
        )

    calplot.calplot(events, edgecolor=None, cmap="YlGn", on_format_coord=format, on_click=click)
    plt.show()
```
### Result:
![hoverandclick](https://user-images.githubusercontent.com/20557666/138182622-1ddff41c-8b1b-4588-a8b9-b134884005bc.gif)
